### PR TITLE
fix: Add missing closing brace to switch statement in header

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -80,6 +80,7 @@ function get_breadcrumbs() {
             case 'report_ap_aging.php':
                 $breadcrumbs[] = '<li class="breadcrumb-item active" aria-current="page">A/P Aging Report</li>';
                 break;
+            }
         }
     }
 


### PR DESCRIPTION
A closing curly brace was missing for the switch statement in the get_breadcrumbs() function. This resulted in a PHP parse error, which broke page rendering across the application.

This commit adds the required closing brace to resolve the syntax error.